### PR TITLE
Removed outdated copyfiles with custom script.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 package-lock.json
+rollup.config.mjs

--- a/README.md
+++ b/README.md
@@ -22,32 +22,4 @@ const lerp = someVar.lerp;
 ```
 Where X.X.X is desired version number.
 
-## Available functions
-
-<table style="width:auto;">
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#clamp">clamp</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#degrees">degrees</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#extent">extent</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#inverseLerp">inverseLerp</a></td>
-  </tr>
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#lerp">lerp</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#max">max</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#mean">mean</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#min">min</a></td>
-  </tr>
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#nrad">nrad</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#radians">radians</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#round">round</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#seq">seq</a></td>
-  </tr>
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#seqI">seqI</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#smoothstep">smoothstep</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#step">step</a></td>
-  </tr>
-</table>
-
 ![Equinor Logo](images/equinor-logo.png)

--- a/docs/functions/clamp.html
+++ b/docs/functions/clamp.html
@@ -46,7 +46,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L13">index.ts:13</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L13">index.ts:13</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/degrees.html
+++ b/docs/functions/degrees.html
@@ -36,7 +36,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L109">index.ts:109</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L109">index.ts:109</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/extent.html
+++ b/docs/functions/extent.html
@@ -36,7 +36,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L255">index.ts:255</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L255">index.ts:255</a></li></ul></aside></li>
 <li class="tsd-signature tsd-anchor-link" id="extent-1"><span class="tsd-kind-call-signature">extent</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span><span class="tsd-kind-parameter">values</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span><a href="#extent-1" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Retrieves the extent of a collection of values.</p>
@@ -56,7 +56,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L265">index.ts:265</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L265">index.ts:265</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/inverseLerp.html
+++ b/docs/functions/inverseLerp.html
@@ -46,7 +46,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L70">index.ts:70</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L70">index.ts:70</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/lerp.html
+++ b/docs/functions/lerp.html
@@ -46,7 +46,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L55">index.ts:55</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L55">index.ts:55</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/max.html
+++ b/docs/functions/max.html
@@ -36,7 +36,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L215">index.ts:215</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L215">index.ts:215</a></li></ul></aside></li>
 <li class="tsd-signature tsd-anchor-link" id="max-1"><span class="tsd-kind-call-signature">max</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span><span class="tsd-kind-parameter">values</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><a href="#max-1" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Retrieves the maximum value among a collection of values.</p>
@@ -56,7 +56,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L225">index.ts:225</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L225">index.ts:225</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/mean.html
+++ b/docs/functions/mean.html
@@ -36,7 +36,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L301">index.ts:301</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L301">index.ts:301</a></li></ul></aside></li>
 <li class="tsd-signature tsd-anchor-link" id="mean-1"><span class="tsd-kind-call-signature">mean</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span><span class="tsd-kind-parameter">values</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><a href="#mean-1" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Find the mean of a collection of values.</p>
@@ -56,7 +56,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L311">index.ts:311</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L311">index.ts:311</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/min.html
+++ b/docs/functions/min.html
@@ -36,7 +36,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L175">index.ts:175</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L175">index.ts:175</a></li></ul></aside></li>
 <li class="tsd-signature tsd-anchor-link" id="min-1"><span class="tsd-kind-call-signature">min</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span><span class="tsd-kind-parameter">values</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><a href="#min-1" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><use href="#icon-anchor"></use></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Retrieves the minimum value among a collection of values.</p>
@@ -56,7 +56,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L185">index.ts:185</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L185">index.ts:185</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/nrad.html
+++ b/docs/functions/nrad.html
@@ -33,7 +33,7 @@
 
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L118">index.ts:118</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L118">index.ts:118</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/radians.html
+++ b/docs/functions/radians.html
@@ -36,7 +36,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L97">index.ts:97</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L97">index.ts:97</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/round.html
+++ b/docs/functions/round.html
@@ -41,7 +41,7 @@
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L84">index.ts:84</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L84">index.ts:84</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/seq.html
+++ b/docs/functions/seq.html
@@ -48,7 +48,7 @@ of steps.</p>
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L135">index.ts:135</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L135">index.ts:135</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/seqI.html
+++ b/docs/functions/seqI.html
@@ -38,7 +38,7 @@ of steps.</p>
 </code><button>Copy</button></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L156">index.ts:156</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L156">index.ts:156</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/smoothstep.html
+++ b/docs/functions/smoothstep.html
@@ -43,7 +43,7 @@
 
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L40">index.ts:40</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L40">index.ts:40</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/step.html
+++ b/docs/functions/step.html
@@ -38,7 +38,7 @@
 
 <div class="tsd-comment tsd-typography"></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/equinor/videx-math/blob/0f2a1ec/src/index.ts#L29">index.ts:29</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/equinor/videx-math/blob/759f382/src/index.ts#L29">index.ts:29</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,32 +22,6 @@
 <a id="md:usage" class="tsd-anchor"></a><h2><a href="#md:usage">Usage</a></h2><pre><code class="language-js"><span class="hl-2">// ES6</span><br/><span class="hl-3">import</span><span class="hl-1"> { </span><span class="hl-0">clamp</span><span class="hl-1">, </span><span class="hl-0">lerp</span><span class="hl-1">, ... } </span><span class="hl-3">from</span><span class="hl-1"> </span><span class="hl-4">&#39;@equinor/videx-math&#39;</span><span class="hl-1">;</span><br/><br/><span class="hl-2">// ObservableHQ</span><br/><span class="hl-5">const</span><span class="hl-1"> </span><span class="hl-6">someVar</span><span class="hl-1"> = </span><span class="hl-7">require</span><span class="hl-1">(</span><span class="hl-4">&#39;@equinor/videx-math@X.X.X/dist/bundle.umd.js&#39;</span><span class="hl-1">);</span><br/><span class="hl-5">const</span><span class="hl-1"> </span><span class="hl-6">lerp</span><span class="hl-1"> = </span><span class="hl-0">someVar</span><span class="hl-1">.</span><span class="hl-0">lerp</span><span class="hl-1">;</span>
 </code><button>Copy</button></pre>
 <p>Where X.X.X is desired version number.</p>
-<a id="md:available-functions" class="tsd-anchor"></a><h2><a href="#md:available-functions">Available functions</a></h2><table style="width:auto;">
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#clamp">clamp</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#degrees">degrees</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#extent">extent</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#inverseLerp">inverseLerp</a></td>
-  </tr>
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#lerp">lerp</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#max">max</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#mean">mean</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#min">min</a></td>
-  </tr>
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#nrad">nrad</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#radians">radians</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#round">round</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#seq">seq</a></td>
-  </tr>
-  <tr>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#seqI">seqI</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#smoothstep">smoothstep</a></td>
-    <td><a href="https://equinor.github.io/videx-math/modules/_index_.html#step">step</a></td>
-  </tr>
-</table>
-
 <p><img src="images/equinor-logo.png" alt="Equinor Logo"></p>
 </div></div>
 <div class="col-sidebar">
@@ -75,8 +49,7 @@
 <li>
 <ul>
 <li><a href="#md:installation"><span>Installation</span></a></li>
-<li><a href="#md:usage"><span>Usage</span></a></li>
-<li><a href="#md:available-functions"><span>Available functions</span></a></li></ul></li></ul></li></ul></div></details></div>
+<li><a href="#md:usage"><span>Usage</span></a></li></ul></li></ul></li></ul></div></details></div>
 <div class="site-menu">
 <nav class="tsd-navigation"><a href="modules.html" class="current"><svg class="tsd-kind-icon" viewBox="0 0 24 24"><g id="icon-4"><rect fill="var(--color-icon-background)" stroke="var(--color-ts-namespace)" stroke-width="1.5" x="1" y="1" width="22" height="22" rx="6"></rect><path d="M9.33 16V7.24H10.77L13.446 14.74C13.43 14.54 13.41 14.296 13.386 14.008C13.37 13.712 13.354 13.404 13.338 13.084C13.33 12.756 13.326 12.448 13.326 12.16V7.24H14.37V16H12.93L10.266 8.5C10.282 8.692 10.298 8.936 10.314 9.232C10.33 9.52 10.342 9.828 10.35 10.156C10.366 10.476 10.374 10.784 10.374 11.08V16H9.33Z" fill="var(--color-text)"></path></g></svg><span>@equinor/videx-<wbr/>math</span></a>
 <ul class="tsd-small-nested-navigation">

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@types/jest": "^29.5.12",
         "@typescript-eslint/eslint-plugin": "^8.4.0",
         "@typescript-eslint/parser": "^8.4.0",
-        "copyfiles": "^2.4.1",
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.30.0",
         "jest": "^29.5.0",
@@ -2675,17 +2674,6 @@
       "integrity": "sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g==",
       "dev": true
     },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2733,31 +2721,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
-    },
-    "node_modules/copyfiles": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
-      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.5",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^1.0.4",
-        "noms": "0.0.0",
-        "through2": "^2.0.1",
-        "untildify": "^4.0.0",
-        "yargs": "^16.1.0"
-      },
-      "bin": {
-        "copyfiles": "copyfiles",
-        "copyup": "copyfiles"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "node_modules/create-jest": {
@@ -4678,12 +4641,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6880,18 +6837,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6915,16 +6860,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
-    },
-    "node_modules/noms": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -7238,12 +7173,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -7316,18 +7245,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
-    },
-    "node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
@@ -7748,12 +7665,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -7961,46 +7872,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -8316,15 +8187,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -8363,12 +8225,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -8584,15 +8440,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8607,33 +8454,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
-    },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -10572,17 +10392,6 @@
       "integrity": "sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g==",
       "dev": true
     },
-    "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10626,27 +10435,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
-    },
-    "copyfiles": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
-      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.5",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^1.0.4",
-        "noms": "0.0.0",
-        "through2": "^2.0.1",
-        "untildify": "^4.0.0",
-        "yargs": "^16.1.0"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "create-jest": {
@@ -12031,12 +11819,6 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -13669,12 +13451,6 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
     },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -13698,16 +13474,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
-    },
-    "noms": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
-      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -13929,12 +13695,6 @@
         }
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -13977,18 +13737,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
-    },
-    "readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
     },
     "regexp.prototype.flags": {
       "version": "1.5.2",
@@ -14296,12 +14044,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -14447,48 +14189,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "tmpl": {
       "version": "1.0.5",
@@ -14701,12 +14401,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "dev": true
-    },
     "update-browserslist-db": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -14725,12 +14419,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.3.0",
@@ -14895,12 +14583,6 @@
         "signal-exit": "^3.0.7"
       }
     },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
-    },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -14911,27 +14593,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
-    },
-    "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src --color",
     "predocs": "rimraf docs",
     "docs": "typedoc --out docs src",
-    "postdocs": "copyfiles images/* docs && copyfiles .nojekyll docs"
+    "postdocs": "node postdocs.copyfiles.mjs"
   },
   "repository": {
     "type": "git",
@@ -40,7 +40,6 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "rollup": "^3.29.4",
-    "copyfiles": "^2.4.1",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.30.0",
     "@typescript-eslint/eslint-plugin": "^8.4.0",

--- a/postdocs.copyfiles.mjs
+++ b/postdocs.copyfiles.mjs
@@ -1,0 +1,34 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+} from 'fs';
+import { join } from 'path';
+
+const brightCyan = '\x1b[96m';
+const brightRed = '\x1b[91m';
+const reset = '\x1b[0m';
+
+function copyImages(source, target) {
+  // Ensure image folder exists
+  if (!existsSync(target)) {
+    mkdirSync(target);
+  }
+
+  const items = readdirSync(source);
+  items.forEach(item => {
+    copyFileSync(
+      join(source, item),
+      join(target, item),
+    );
+  });
+}
+
+if (existsSync('./docs')) {
+  copyImages('./images', './docs/images');
+  copyFileSync('./.nojekyll', './docs/.nojekyll');
+  console.log(`${brightCyan}[info]${reset} Images and .nojekyll files copied into ./docs`);
+} else {
+  console.log(`${brightRed}[error]${reset} Docs directory does not exist, skipping file copy`);
+}

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -9,7 +9,7 @@ import { readFileSync } from 'node:fs';
 // file instead of process.cwd(). For more information:
 // https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaurl
 const pkg = JSON.parse(
-	readFileSync(new URL('./package.json', import.meta.url))
+	readFileSync(new URL('./package.json', import.meta.url)),
 );
 
 export default [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,15 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "./dist",
-    "module": "es6",
+    "module": "ESNext",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "outDir": "./dist",
-    "target": "es5"
+    "target": "ES6"
   },
   "include": [
-    "src/*"
+    "src/*",
+    "postdocs.copyfiles.mjs"
   ],
   "exclude": ["node_modules"],
 }


### PR DESCRIPTION
Fixes [#49](https://github.com/equinor/videx-math/issues/49)

This is the last vulnerability PR until Jest releases v30.