### PR TITLE
docs: improvement suggestions for the documentation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { RAD2DEG, DEG2RAD, TAU } from './const';
  * @param value Value to clamp
  * @param min Minimum value (Default: 0)
  * @param max Maximum value (Default: 1)
- * @return Clamped value
+ * @returns Clamped value
  *
  * @example
  * clamp(8, 3, 7); // Returns: 7
@@ -24,7 +24,7 @@ export function clamp(value: number, min: number = 0, max: number = 1): number {
  * Generate a step function by comparing two values.
  * @param edge Edge of the step function
  * @param x Value used to generate the step function
- * @return Returns either 0 or 1
+ * @returns Returns either 0 or 1
  */
 export function step(edge: number, x: number): number {
   return x >= edge ? 1 : 0;
@@ -35,7 +35,7 @@ export function step(edge: number, x: number): number {
  * @param edge0 Lower edge of the Hermite function
  * @param edge1 Upper edge of the Hermite function
  * @param x Source value for interpolation
- * @return Hermite interpolated value
+ * @returns Hermite interpolated value
  */
 export function smoothstep(edge0: number, edge1: number, x: number): number {
   const t = clamp((x - edge0) / (edge1 - edge0));
@@ -47,7 +47,7 @@ export function smoothstep(edge0: number, edge1: number, x: number): number {
  * @param a Number to interpolate from
  * @param b Number to interpolate to
  * @param t Interpolation parameter, 0 = a and 1 = b
- * @return The interpolated value
+ * @returns The interpolated value
  *
  * @example
  * lerp(2, 4, 0.5); // Returns 3
@@ -62,7 +62,7 @@ export function lerp(a: number, b: number, t: number): number {
  * @param a Start value
  * @param b End value
  * @param value Value between start and end
- * @return Percentage of value between start and end
+ * @returns Percentage of value between start and end
  *
  * @example
  * inverseLerp(2, 4, 3); // Returns 0.5
@@ -111,9 +111,9 @@ export function degrees(rad: number): number {
 }
 
 /**
- * Normalise an angle to be between -π and +π.
+ * Normalise an angle to be between 0 and 2π.
  * @param rad Angle in radians
- * @return Normalised angle
+ * @returns Normalised angle
  */
 export function nrad(rad: number): number {
   const v = rad % TAU;
@@ -210,7 +210,7 @@ export function min(a: number | number[], ...b: number[]): number {
  * @returns Maximum value
  *
  * @example
- * min([2, 1, 3]); // Returns 3
+ * max([2, 1, 3]); // Returns 3
  */
 export function max(values: number[]): number
 
@@ -220,7 +220,7 @@ export function max(values: number[]): number
  * @returns Maximum value
  *
  * @example
- * min(2, 1, 3); // Returns 3
+ * max(2, 1, 3); // Returns 3
  */
 export function max(...values: number[]): number
 
@@ -250,7 +250,7 @@ export function max(a: number | number[], ...b: number[]): number {
  * @returns Extent on format [min, max]
  *
  * @example
- * min([2, 1, 3]); // Returns [1, 3]
+ * extent([2, 1, 3]); // Returns [1, 3]
  */
 export function extent(values: number[]): [number, number]
 
@@ -260,7 +260,7 @@ export function extent(values: number[]): [number, number]
  * @returns Extent on format [min, max]
  *
  * @example
- * min(2, 1, 3); // Returns [1, 3]
+ * extent(2, 1, 3); // Returns [1, 3]
  */
 export function extent(...values: number[]): [number, number]
 


### PR DESCRIPTION
List of suggested changes:
- update `@return` to `@returns` to align with most of the documentation
- fix `nrad` doc as it looks like the range is in [0; 2π] , and not [-π; π]
- fix documentation for `max` (copy-pasted from min)
- fix documentation for `extent` (copy-pasted from min)